### PR TITLE
Feature/part13: pixel FIFO pipeline to show bg

### DIFF
--- a/CBoy/include/ppu.h
+++ b/CBoy/include/ppu.h
@@ -7,6 +7,39 @@ static const int TICKS_PER_LINE = 456; //tick means dot (pandocs)
 static const int YRES = 144; //resolution
 static const int XRES = 160;
 
+typedef enum {
+    FS_TILE,
+    FS_DATA0,
+    FS_DATA1,
+    FS_IDLE, //sleep state
+    FS_PUSH
+} fetch_state;
+
+typedef struct _fifo_entry {
+    struct _fifo_entry *next;
+    u32 value;
+} fifo_entry;
+
+typedef struct {
+    fifo_entry *head;
+    fifo_entry *tail;
+    u32 size;
+} fifo;
+
+typedef struct {
+    fetch_state cur_fetch_state;
+    fifo pixel_fifo;
+    u8 line_x;
+    u8 pushed_x;
+    u8 fetch_x; //cur fetching
+    u8 bgw_fetch_data[3]; //different temp tiles fetching
+    u8 fetch_entry_data[6]; //temp oam data fetching
+    u8 map_y;
+    u8 map_x;
+    u8 tile_y;
+    u8 fifo_x;
+} pixel_fifo_context;
+
 typedef struct {
     u8 y;
     u8 x;
@@ -33,6 +66,8 @@ typedef struct {
     oam_entry oam_ram[40];
     u8 vram[0x2000];
 
+    pixel_fifo_context pfc;
+
     u32 current_frame;
     u32 line_ticks; //how many ticks (dots) there are in cur frame
     u32 *video_buffer;
@@ -48,3 +83,6 @@ void ppu_vram_write(u16 address, u8 value);
 u8 ppu_vram_read(u16 address);
 
 ppu_context *ppu_get_context();
+
+void pipeline_process();
+void pipeline_fifo_reset();

--- a/CBoy/include/ui.h
+++ b/CBoy/include/ui.h
@@ -2,8 +2,8 @@
 
 #include <common.h>
 
-static const int SCREEN_WIDTH = 512;
-static const int SCREEN_HEIGHT = 384;
+static const int SCREEN_WIDTH = 1024;
+static const int SCREEN_HEIGHT = 768;
 
 void ui_init();
 void ui_handle_events();

--- a/CBoy/lib/cpu.c
+++ b/CBoy/lib/cpu.c
@@ -7,7 +7,7 @@
 
 cpu_context ctx = {0};
 
-#define CPU_DEBUG 1
+#define CPU_DEBUG 0
 
 void cpu_init() {
     ctx.regs.pc = 0x100;

--- a/CBoy/lib/ppu.c
+++ b/CBoy/lib/ppu.c
@@ -14,6 +14,13 @@ void ppu_init() {
     ctx.line_ticks = 0;
     ctx.video_buffer = malloc(YRES * XRES * sizeof(u32));
 
+    ctx.pfc.line_x = 0;
+    ctx.pfc.pushed_x = 0;
+    ctx.pfc.fetch_x = 0;
+    ctx.pfc.pixel_fifo.size = 0;
+    ctx.pfc.pixel_fifo.head = ctx.pfc.pixel_fifo.tail = NULL;
+    ctx.pfc.cur_fetch_state = FS_TILE;
+
     lcd_init();
     LCDS_MODE_SET(MODE_OAM);
 

--- a/CBoy/lib/ppu_pipeline.c
+++ b/CBoy/lib/ppu_pipeline.c
@@ -1,0 +1,143 @@
+#include <ppu.h>
+#include <lcd.h>
+#include <bus.h>
+
+void pixel_fifo_push(u32 value) {
+    //fifo inner util func, standard linked-list push operation
+    fifo_entry *next = malloc(sizeof(fifo_entry));
+    next->next = NULL;
+    next->value = value;
+
+    if (!ppu_get_context()->pfc.pixel_fifo.head) {
+        //first entry
+        ppu_get_context()->pfc.pixel_fifo.head = ppu_get_context()->pfc.pixel_fifo.tail = next;
+    } else {
+        ppu_get_context()->pfc.pixel_fifo.tail->next = next;
+        ppu_get_context()->pfc.pixel_fifo.tail = next;
+    }
+
+    ppu_get_context()->pfc.pixel_fifo.size++;
+}
+
+u32 pixel_fifo_pop() {
+    //fifo inner util func, standard linked-list pop operation
+    if (ppu_get_context()->pfc.pixel_fifo.size <= 0) {
+        fprintf(stderr, "ERROR IN PIXEL FIFO POP");
+        exit(-8);
+    }
+
+    fifo_entry *poped = ppu_get_context()->pfc.pixel_fifo.head;
+    ppu_get_context()->pfc.pixel_fifo.head = poped->next;
+    ppu_get_context()->pfc.pixel_fifo.size--;
+
+    u32 val = poped->value;
+    free(poped);
+
+    return val;
+}
+
+bool pipeline_fifo_add() {
+    if (ppu_get_context()->pfc.pixel_fifo.size > 8) {
+        //fifo is full
+        return false;
+    }
+
+    int x = ppu_get_context()->pfc.fetch_x - (8 - (lcd_get_context()->scroll_x % 8)); //x=8 is the 1st location visible on the screen
+
+    for (int i = 0; i < 8; i++) {
+        int bit = 7 - i;
+        u8 low = !!(ppu_get_context()->pfc.bgw_fetch_data[1] & (1 << bit));
+        u8 high = !!(ppu_get_context()->pfc.bgw_fetch_data[2] & (1 << bit)) << 1;
+        u32 color = lcd_get_context()->bg_colors[low | high];
+
+        if (x >= 0) {
+            //push that color onto the fifo
+            pixel_fifo_push(color);
+            ppu_get_context()->pfc.fifo_x++;
+        }
+    }
+
+    return true;
+}
+
+void pipeline_fetch() {
+    switch(ppu_get_context()->pfc.cur_fetch_state) {
+        case FS_TILE: {
+            //fetch the cur tile for the location we are on the map
+            if (LCDC_BGW_ENABLE) {
+                ppu_get_context()->pfc.bgw_fetch_data[0] = bus_read(LCDC_BG_MAP_AREA +
+                    ppu_get_context()->pfc.map_x / 8 +
+                    (ppu_get_context()->pfc.map_y / 8) * 32);
+                
+                if (LCDC_BGW_DATA_AREA == 0x8800) {
+                    ppu_get_context()->pfc.bgw_fetch_data[0] += 128; //increment id for that tile
+                }
+            }
+
+            //switch to next state
+            ppu_get_context()->pfc.cur_fetch_state = FS_DATA0;
+            ppu_get_context()->pfc.fetch_x += 8;
+        } break;
+        case FS_DATA0: {
+            ppu_get_context()->pfc.bgw_fetch_data[1] = bus_read(LCDC_BGW_DATA_AREA +
+                ppu_get_context()->pfc.bgw_fetch_data[0] * 16 +
+                ppu_get_context()->pfc.tile_y);
+
+                ppu_get_context()->pfc.cur_fetch_state = FS_DATA1;
+        } break;
+        case FS_DATA1: {
+            ppu_get_context()->pfc.bgw_fetch_data[2] = bus_read(LCDC_BGW_DATA_AREA +
+                ppu_get_context()->pfc.bgw_fetch_data[0] * 16 +
+                ppu_get_context()->pfc.tile_y + 1);
+
+                ppu_get_context()->pfc.cur_fetch_state = FS_IDLE;
+        } break;
+        case FS_IDLE: {
+                ppu_get_context()->pfc.cur_fetch_state = FS_PUSH;
+        } break;
+        case FS_PUSH: {
+            if (pipeline_fifo_add()) {
+                //keep pushing until succeed
+                ppu_get_context()->pfc.cur_fetch_state = FS_TILE;
+            }
+        } break;
+    }
+}
+
+void pipeline_push_pixel() {
+    if (ppu_get_context()->pfc.pixel_fifo.size > 8) {
+        //if fifo full, start pushing 
+        u32 pixel_data = pixel_fifo_pop();
+
+        if (ppu_get_context()->pfc.line_x >= (lcd_get_context()->scroll_x % 8)) {
+            ppu_get_context()->video_buffer[ppu_get_context()->pfc.pushed_x + 
+                lcd_get_context()->ly * XRES] = pixel_data;
+
+                ppu_get_context()->pfc.pushed_x++;
+        }
+
+        ppu_get_context()->pfc.line_x++;
+    }
+}
+
+void pipeline_process() {
+    ppu_get_context()->pfc.map_y = lcd_get_context()->ly + lcd_get_context()->scroll_y;
+    ppu_get_context()->pfc.map_x = ppu_get_context()->pfc.fetch_x + lcd_get_context()->scroll_x;
+    ppu_get_context()->pfc.tile_y = ((lcd_get_context()->ly + lcd_get_context()->scroll_y) % 8) * 2; //y-value on cur tile
+
+    if (!ppu_get_context()->line_ticks & 1) {
+        //first bit is not set (on a even line instead of odd line)
+        pipeline_fetch();
+    }
+
+    pipeline_push_pixel();
+}
+
+void pipeline_fifo_reset() {
+    //reset when done with fifo
+    while (ppu_get_context()->pfc.pixel_fifo.size) {
+        pixel_fifo_pop();
+    }
+
+    ppu_get_context()->pfc.pixel_fifo.head = 0;
+}

--- a/CBoy/lib/ppu_sm.c
+++ b/CBoy/lib/ppu_sm.c
@@ -20,11 +20,26 @@ void increment_ly() {
 void ppu_mode_oam() {
     if (ppu_get_context()->line_ticks >= 80) {
         LCDS_MODE_SET(MODE_XFER);
+
+        ppu_get_context()->pfc.cur_fetch_state = FS_TILE;
+        ppu_get_context()->pfc.line_x = 0;
+        ppu_get_context()->pfc.fetch_x = 0;
+        ppu_get_context()->pfc.pushed_x = 0;
+        ppu_get_context()->pfc.fifo_x = 0;
     }
 }
 void ppu_mode_xfer() {
-    if (ppu_get_context()->line_ticks >= 80 + 172) {
+    pipeline_process();
+
+    if (ppu_get_context()->pfc.pushed_x >= XRES) {
+        //when we pushed all the pixels that we can push
+        pipeline_fifo_reset();
+
         LCDS_MODE_SET(MODE_HBLANK);
+
+        if (LCDC_STAT_INT(SS_HBLANK)) {
+            cpu_request_interrupt(IT_LCD_STAT);
+        }
     }
 }
 

--- a/CBoy/lib/ui.c
+++ b/CBoy/lib/ui.c
@@ -1,6 +1,7 @@
 #include <ui.h>
 #include <emu.h>
 #include <bus.h>
+#include <ppu.h>
 
 #include <SDL2/SDL.h>
 #include <SDL2/SDL_ttf.h>
@@ -25,6 +26,16 @@ void ui_init() {
     printf("TTF INIT\n");
 
     SDL_CreateWindowAndRenderer(SCREEN_WIDTH, SCREEN_HEIGHT, 0, &sdlWindow, &sdlRenderer);
+
+    screen = SDL_CreateRGBSurface(0, SCREEN_WIDTH, SCREEN_HEIGHT, 32,
+                                            0x00FF0000,
+                                            0x0000FF00,
+                                            0x000000FF,
+                                            0xFF000000);
+    sdlTexture = SDL_CreateTexture(sdlRenderer,
+                                                SDL_PIXELFORMAT_ARGB8888,
+                                                SDL_TEXTUREACCESS_STREAMING,
+                                                SCREEN_WIDTH, SCREEN_HEIGHT);
 
     SDL_CreateWindowAndRenderer(16 * 8 * scale, 32 * 8 * scale, 0, 
         &sdlDebugWindow, &sdlDebugRenderer);
@@ -61,15 +72,14 @@ void display_tile(SDL_Surface *surface, u16 startLocation, u16 tileNum, int x, i
     SDL_Rect rc;
 
     for (int tileY=0; tileY<16; tileY += 2) {
-        // 16 Bytes for each tile, each line is 2 bytes
-        u8 b1 = bus_read(startLocation + (tileNum * 16) + tileY); // byte1 in a line
-        u8 b2 = bus_read(startLocation + (tileNum * 16) + tileY + 1); // byte2 in a line
+        u8 b1 = bus_read(startLocation + (tileNum * 16) + tileY);
+        u8 b2 = bus_read(startLocation + (tileNum * 16) + tileY + 1);
 
         for (int bit=7; bit >= 0; bit--) {
             u8 hi = !!(b1 & (1 << bit)) << 1;
             u8 lo = !!(b2 & (1 << bit));
 
-            u8 color = hi | lo; // color for the current pixel
+            u8 color = hi | lo;
 
             rc.x = x + ((7 - bit) * scale);
             rc.y = y + (tileY / 2 * scale);
@@ -114,6 +124,28 @@ void update_dbg_window() {
 }
 
 void ui_update() {
+    SDL_Rect rc;
+    rc.x = rc.y = 0;
+    rc.w = rc.h = 2048;
+
+    u32 *video_buffer = ppu_get_context()->video_buffer;
+
+    for (int line_num = 0; line_num < YRES; line_num++) {
+        for (int x = 0; x < XRES; x++) {
+            rc.x = x * scale;
+            rc.y = line_num * scale;
+            rc.w = scale;
+            rc.h = scale;
+
+            SDL_FillRect(screen, &rc, video_buffer[x + (line_num * XRES)]);
+        }
+    }
+
+    SDL_UpdateTexture(sdlTexture, NULL, screen->pixels, screen->pitch);
+    SDL_RenderClear(sdlRenderer);
+    SDL_RenderCopy(sdlRenderer, sdlTexture, NULL, NULL);
+    SDL_RenderPresent(sdlRenderer);
+
     update_dbg_window();
 }
 
@@ -130,4 +162,3 @@ void ui_handle_events() {
         }
     }
 }
-

--- a/CBoy/lib/ui.c
+++ b/CBoy/lib/ui.c
@@ -162,3 +162,4 @@ void ui_handle_events() {
         }
     }
 }
+

--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Setup:
 1. clone the repo to your local directory 
 ```bash
 git clone https://github.com/SimpleCodeJust4Fun/cBoy.git
-cd LLD_GEBEMU
-cd part16
+cd CBoy
 ```
 2. use cmake to construct the project
 ```bash
@@ -69,5 +68,3 @@ Windows Environment Setup:
 5. pacman -S mingw-w64-x86_64-check
 
 After above steps you should be able to build from Windows using MSYS2 just like in the videos.
-
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Deploy Env
 - Compiler: Apple clang version 15.0.0 (clang-1500.1.0.2.5) from Apple's default CommandLineTools
 - Other requirements: Homebrew 4.2.0
   
-setup:
+Setup:
 1. clone the repo to your local directory 
 ```bash
 git clone https://github.com/SimpleCodeJust4Fun/cBoy.git


### PR DESCRIPTION
- implement pixel FIFO pipeline
    - standard linked-list based FIFO
    - GameBoy specified FIFO states, FIFO context
- use FIFO to render background tiles. 
- rendering for sprite and window is not supported yet